### PR TITLE
permissions for bind in apparmor

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,13 @@ chown -R bind /var/log/bind
 chmod u+rw /var/log/bind
 ```
 
+##### Editar el fichero /etc/apparmor.d/usr.sbin.named y añadir las líneas
+
+```bash
+/var/log/bind/** rw,
+/var/log/bind/ rw,
+```
+
 ```bash
 nano /etc/bind/named.conf.logging
 


### PR DESCRIPTION
El servicio bind9 puede dar errores de permisos en los ficheros de logs en /var/log/bind luego de poner las configuraciones de logging, a la hora de reniciarlo. Este error no se soluciona incluso después de tener permisos de sistema de archivos. Una vía para solucionarlo es editar el /etc/apparmor.d/usr.sbin.named, como se muestra en el commit. Solución encontrada en https://cutt.ly/bl9UsPF
